### PR TITLE
Corrected typo in readme from 'lida.modules' to 'lida.components'

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The fastest and recommended way to get started after installation will be to try
 Given a dataset, generate a compact summary of the data.
 
 ```python
-from lida.modules import Manager
+from lida.components import Manager
 
 lida = Manager()
 summary = lida.summarize("data/cars.json") # generate data summary


### PR DESCRIPTION
There was a slight error in the docs, where it states 
```python
from lida.modules import Manager
```

I corrected this to 
```python
from lida.components import Manager
```
