### PR TITLE
Introduce reprs for some of the base objects

### DIFF
--- a/lida/datamodel.py
+++ b/lida/datamodel.py
@@ -1,13 +1,15 @@
 # from dataclasses import dataclass
 from dataclasses import field
 from typing import Any, Dict, List, Optional, Union
-from pydantic.dataclasses import dataclass
+
 from llmx import TextGenerationConfig
+from pydantic.dataclasses import dataclass
 
 
 @dataclass
 class VizGeneratorConfig:
     """Configuration for a visualization generation"""
+
     hypothesis: str
     data_summary: Optional[str] = ""
     data_filename: Optional[str] = "cars.csv"
@@ -24,12 +26,14 @@ class CompletionResult:
 @dataclass
 class UploadUrl:
     """Response from a text generation"""
+
     url: str
 
 
 @dataclass
 class Goal:
     """A visualization goal"""
+
     index: int
     question: str
     visualization: str
@@ -50,6 +54,7 @@ class Goal:
 @dataclass
 class Summary:
     """A summary of a dataset"""
+
     name: str
     file_name: str
     dataset_description: str
@@ -60,80 +65,113 @@ class Summary:
 @dataclass
 class GoalWebRequest:
     """A Goal Web Request"""
+
     summary: Summary
-    textgen_config: Optional[TextGenerationConfig] = field(default_factory=TextGenerationConfig)
+    textgen_config: Optional[TextGenerationConfig] = field(
+        default_factory=TextGenerationConfig
+    )
     n: int = 5
 
 
 @dataclass
 class VisualizeWebRequest:
     """A Visualize Web Request"""
+
     summary: Summary
     goal: Goal
     library: str = "seaborn"
-    textgen_config: Optional[TextGenerationConfig] = field(default_factory=TextGenerationConfig)
+    textgen_config: Optional[TextGenerationConfig] = field(
+        default_factory=TextGenerationConfig
+    )
 
 
 @dataclass
 class VisualizeRecommendRequest:
     """A Visualize Recommendation Request"""
+
     summary: Summary
     code: str
     library: str = "seaborn"
-    textgen_config: Optional[TextGenerationConfig] = field(default_factory=TextGenerationConfig)
+    textgen_config: Optional[TextGenerationConfig] = field(
+        default_factory=TextGenerationConfig
+    )
 
 
 @dataclass
 class VisualizeEditWebRequest:
     """A Visualize Edit Web Request"""
+
     summary: Summary
     code: str
     instructions: Union[str, List[str]]
     library: str = "seaborn"
-    textgen_config: Optional[TextGenerationConfig] = field(default_factory=TextGenerationConfig)
+    textgen_config: Optional[TextGenerationConfig] = field(
+        default_factory=TextGenerationConfig
+    )
 
 
 @dataclass
 class VisualizeRepairWebRequest:
     """A Visualize Repair Web Request"""
+
     feedback: Optional[Union[str, List[str], List[Dict]]]
     code: str
     goal: Goal
     summary: Summary
     library: str = "seaborn"
-    textgen_config: Optional[TextGenerationConfig] = field(default_factory=TextGenerationConfig)
+    textgen_config: Optional[TextGenerationConfig] = field(
+        default_factory=TextGenerationConfig
+    )
 
 
 @dataclass
 class VisualizeExplainWebRequest:
     """A Visualize Explain Web Request"""
+
     code: str
     library: str = "seaborn"
-    textgen_config: Optional[TextGenerationConfig] = field(default_factory=TextGenerationConfig)
+    textgen_config: Optional[TextGenerationConfig] = field(
+        default_factory=TextGenerationConfig
+    )
 
 
 @dataclass
 class VisualizeEvalWebRequest:
     """A Visualize Eval Web Request"""
+
     code: str
     goal: Goal
     library: str = "seaborn"
-    textgen_config: Optional[TextGenerationConfig] = field(default_factory=TextGenerationConfig)
+    textgen_config: Optional[TextGenerationConfig] = field(
+        default_factory=TextGenerationConfig
+    )
 
 
 @dataclass
 class ChartExecutorResponse:
     """Response from a visualization execution"""
+
     spec: Optional[Union[str, Dict]]  # interactive specification e.g. vegalite
-    status: bool         # True if successful
+    status: bool  # True if successful
     raster: Optional[str]  # base64 encoded image
-    code: str           # code used to generate the visualization
-    library: str     # library used to generate the visualization
-    error: Optional[Dict] = None       # error message if status is False
+    code: str  # code used to generate the visualization
+    library: str  # library used to generate the visualization
+    error: Optional[Dict] = None  # error message if status is False
+
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        bundle = {"text/plain": self.code}
+        if self.raster is not None:
+            bundle["image/png"] = self.raster
+        if self.spec is not None:
+            bundle["application/vnd.vegalite.v5+json"] = self.spec
+
+        return bundle
+
 
 @dataclass
 class InfographicsRequest:
     """A request for infographics generation"""
+
     visualization: str
     n: int = 1
     style_prompt: Union[str, List[str]] = ""

--- a/lida/datamodel.py
+++ b/lida/datamodel.py
@@ -35,6 +35,17 @@ class Goal:
     visualization: str
     rationale: str
 
+    def _repr_markdown_(self):
+        return f"""
+### Goal {self.index}
+
+**Question:** {self.question}
+
+**Visualization:** `{self.visualization}`
+
+**Rationale:** {self.rationale}
+"""
+
 
 @dataclass
 class Summary:


### PR DESCRIPTION
This introduces ipython / Jupyter representations for Python objects to allow easier viewing in a notebook.

For instance, running this code will display all the charts from `lida.visualize`

> ```python
> i = 0
> library = "seaborn"
> textgen_config = TextGenerationConfig(n=1, temperature=0.2, use_cache=True)
> charts = lida.visualize(
>     summary=summary, goal=goals[i], textgen_config=textgen_config, library=library
> )
> for chart in charts:
>     display(chart)
> ```
> 
> ![image](https://github.com/microsoft/lida/assets/836375/e64f0891-cb9b-4acf-b49c-8ac67468d42e)

and you can also just the `chart` be the execution result for the cell:

> ```python
> library = "seaborn"
> textgen_config = TextGenerationConfig(n=1, temperature=0.2, use_cache=True)
> charts = lida.visualize(
>     summary=summary, goal=goals[i], textgen_config=textgen_config, library=library
> )
> charts[0]
> ```
> 
> ![image](https://github.com/microsoft/lida/assets/836375/e64f0891-cb9b-4acf-b49c-8ac67468d42e)

Additionally, I did the same for goals:

![image](https://github.com/microsoft/lida/assets/836375/7ae2b153-a2d8-434b-9d32-cf873e1c2e39)

Working on updating the notebook example as well once my machine has the infographics dependencies working well.