### PR TITLE
Fix : Cant install kaleido 0.2.1.post1 with poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "geopandas",
     "matplotlib-venn",
     "wordcloud",
-    "kaleido"
+    "kaleido>=0.2.1, !=0.2.1.post1"
 ]
 optional-dependencies = {web = ["fastapi", "uvicorn"], transformers = ["llmx[transformers]"], tools=["geopy", "basemap", "basemap-data-hires"], infographics=["peacasso"]}
 


### PR DESCRIPTION
In our project we are using lida and poetry as dependency manager . kaleido's latest release 0.2.1.post1 cannot be used in windows . pypi is able to recognise it while using `pip install lida` , but not for poetry when using `poetry add lida`
[poetry issue](https://github.com/python-poetry/poetry/issues/4046)
poetry throwing error
![image](https://github.com/microsoft/lida/assets/63579905/5a43fb56-de85-4482-b5e2-b06dc4efe7a3)

So updated pyproject.toml to ignore the specific release alone 
[Kaleido introduced commit for reference](https://github.com/microsoft/lida/pull/44/commits/74473b3371a864932e951a9b08e6bff0a92f3c60)