### PR TITLE
Enhance compatibility with `hf`  `gemma2-2b-it`

### DIFF
--- a/lida/components/executor.py
+++ b/lida/components/executor.py
@@ -20,6 +20,8 @@ def preprocess_code(code: str) -> str:
     code = code.replace("<imports>", "")
     code = code.replace("<stub>", "")
     code = code.replace("<transforms>", "")
+    code = code.replace(" import", "import")
+    code = code.replace(" def", "def")
 
     # remove all text after chart = plot(data)
     if "chart = plot(data)" in code:


### PR DESCRIPTION
I have modified the `preprocess_code` function in `lida/components/executor.py` to address indentation issues related to the "import" and "def" keywords. This adjustment enhances LIDA's compatibility with smaller language models, such as Gemma-2 2B, which previously encountered errors due to these formatting inconsistencies.

By implementing these small changes, I successfully integrated LIDA into my project that utilizes smaller LLMs. This contribution aims to broaden LIDA's applicability across diverse LLM environments.

I am eager to continue contributing to LIDA, focusing on further optimizations for smaller models and exploring potential compatibility with platforms like Ollama. I look forward to feedback from the maintainers and the opportunity to collaborate on enhancing LIDA's versatility.